### PR TITLE
support generate client with given local swagger.json

### DIFF
--- a/openapi/Dockerfile
+++ b/openapi/Dockerfile
@@ -46,6 +46,7 @@ RUN chmod go+rwx /root && umask 0 && cd /source/swagger-codegen && \
 COPY generate_client_in_container.sh /generate_client.sh
 COPY preprocess_spec.py /
 COPY custom_objects_spec.json /
+COPY swagger.json /
 COPY ${GENERATION_XML_FILE} /generation_params.xml
 
 ENTRYPOINT ["mvn-entrypoint.sh", "/generate_client.sh"]

--- a/openapi/generate_client_in_container.sh
+++ b/openapi/generate_client_in_container.sh
@@ -79,7 +79,7 @@ popd
 mkdir -p "${output_dir}"
 
 echo "--- Downloading and pre-processing OpenAPI spec"
-python "${SCRIPT_ROOT}/preprocess_spec.py" "${CLIENT_LANGUAGE}" "${KUBERNETES_BRANCH}" "${output_dir}/swagger.json" "${USERNAME}" "${REPOSITORY}"
+python "${SCRIPT_ROOT}/preprocess_spec.py" "${CLIENT_LANGUAGE}" "${KUBERNETES_BRANCH}" "${output_dir}/swagger.json" "${USERNAME}" "${REPOSITORY}" "${SCRIPT_ROOT}/swagger.json"
 
 echo "--- Cleaning up previously generated folders"
 for i in ${CLEANUP_DIRS}; do


### PR DESCRIPTION
Instead of maintaining `swagger.json` on github, I think generating it with our tool `genspec` whenever needed will be a better choice. So I added an argument to `preprocess_spec.py` to process local spec other than downloading from github.

Signed-off-by: JetMuffin <mofeng.cj@alibaba-inc.com>